### PR TITLE
Added an optional argument for specifying the step...

### DIFF
--- a/Rebus.TransactionScopes/Config/TransactionScopeConfigurationExtensions.cs
+++ b/Rebus.TransactionScopes/Config/TransactionScopeConfigurationExtensions.cs
@@ -14,7 +14,7 @@ namespace Rebus.Config
         /// <summary>
         /// Configures Rebus to execute handlers inside a <see cref="System.Transactions.TransactionScope"/>. Uses Rebus' default transaction
         /// options which is <see cref="System.Data.IsolationLevel.ReadCommitted"/> isolation level and 1 minut timeout.
-        /// Use the <see cref="HandleMessagesInsideTransactionScope(OptionsConfigurer, System.Transactions.TransactionOptions)"/> if you
+        /// Use the <see cref="HandleMessagesInsideTransactionScope(OptionsConfigurer, System.Transactions.TransactionOptions, Type)"/> if you
         /// want to customize the transaction settings.
         /// </summary>
         public static void HandleMessagesInsideTransactionScope(this OptionsConfigurer configurer)

--- a/Rebus.TransactionScopes/Config/TransactionScopeConfigurationExtensions.cs
+++ b/Rebus.TransactionScopes/Config/TransactionScopeConfigurationExtensions.cs
@@ -30,11 +30,15 @@ namespace Rebus.Config
 
         /// <summary>
         /// Configures Rebus to execute handlers inside a <see cref="TransactionScope"/>, using the transaction options
-        /// given by <paramref name="transactionOptions"/> for the transaction scope
+        /// given by <paramref name="transactionOptions"/> for the transaction scope. If <paramref name="injectBeforeStepType"/> is
+        /// defined, it will be used as the anchor step type for injection in the incoming step pipleine. The default is <see cref="DispatchIncomingMessageStep" />
+        /// if it is not defined.
         /// </summary>
-        public static void HandleMessagesInsideTransactionScope(this OptionsConfigurer configurer, TransactionOptions transactionOptions)
+        public static void HandleMessagesInsideTransactionScope(this OptionsConfigurer configurer, TransactionOptions transactionOptions, Type injectBeforeStepType = null)
         {
             if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+
+            injectBeforeStepType = injectBeforeStepType ?? typeof(DispatchIncomingMessageStep);
 
             configurer.Decorate<IPipeline>(c =>
             {
@@ -42,7 +46,7 @@ namespace Rebus.Config
                 var stepToInject = new TransactionScopeIncomingStep(transactionOptions);
 
                 return new PipelineStepInjector(pipeline)
-                    .OnReceive(stepToInject, PipelineRelativePosition.Before, typeof(DispatchIncomingMessageStep));
+                    .OnReceive(stepToInject, PipelineRelativePosition.Before, injectBeforeStepType);
             });
         }
     }


### PR DESCRIPTION
… which the TransactionScopeIncomingStep should be injected in front of, to handle the use case when one want to include the saga loading inside the transaction scope.

Could not find a good test strategy for checking that the step injection is correct, so no test case added.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
