### PR TITLE
Fix issue #7

### DIFF
--- a/Rebus.TransactionScopes.Tests/TestTransactionScopeSupport.cs
+++ b/Rebus.TransactionScopes.Tests/TestTransactionScopeSupport.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Transactions;
 using NUnit.Framework;
 using Rebus.Activation;
@@ -24,6 +25,7 @@ namespace Rebus.TransactionScopes.Tests
 
             activator.Handle<string>(async str =>
             {
+                await Task.Delay(10);
                 detectedAmbientTransaction = Transaction.Current != null;
 
                 done.Set();

--- a/Rebus.TransactionScopes/TransactionScopes/Step.cs
+++ b/Rebus.TransactionScopes/TransactionScopes/Step.cs
@@ -27,16 +27,10 @@ namespace Rebus.TransactionScopes
                 return;
             }
 
-            var previous = Transaction.Current;
-            try
+            using (var scope = new TransactionScope(transaction, TransactionScopeAsyncFlowOption.Enabled))
             {
-                Transaction.Current = transaction;
-
                 await next();
-            }
-            finally
-            {
-                Transaction.Current = previous;
+                scope.Complete();
             }
         }
     }


### PR DESCRIPTION
Fixes #7 by ensuring the ambient `Transaction` flows across async continuations by wrapping it inside a `TransactionScope`.

-----
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
