### PR TITLE
Upgrade to Rebus 6.0.0 and fix a few minor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rebus.TransactionScopes
 
-[![install from nuget](https://img.shields.io/nuget/v/Rebus.TransactionScope.svg?style=flat-square)](https://www.nuget.org/packages/Rebus.TransactionScope)
+[![install from nuget](https://img.shields.io/nuget/v/Rebus.TransactionScopes.svg?style=flat-square)](https://www.nuget.org/packages/Rebus.TransactionScopes)
 
 Provides a `System.Transactions.TransactionScope` helper for [Rebus](https://github.com/rebus-org/Rebus).
 

--- a/Rebus.TransactionScopes.Tests/Rebus.TransactionScopes.Tests.csproj
+++ b/Rebus.TransactionScopes.Tests/Rebus.TransactionScopes.Tests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Rebus" Version="4.0.0" />
     <PackageReference Include="Rebus.Tests.Contracts" Version="4.0.0" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework) == 'net451' ">
     <Reference Include="System.Transactions" />
   </ItemGroup>
 </Project>

--- a/Rebus.TransactionScopes.Tests/Rebus.TransactionScopes.Tests.csproj
+++ b/Rebus.TransactionScopes.Tests/Rebus.TransactionScopes.Tests.csproj
@@ -36,11 +36,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.TransactionScopes\Rebus.TransactionScopes.csproj" />
-    <PackageReference Include="microsoft.net.test.sdk" Version="15.9.0" />
-    <PackageReference Include="nunit" Version="3.7.1" />
-    <PackageReference Include="nunit3testadapter" Version="3.12.0" />
-    <PackageReference Include="Rebus" Version="4.0.0" />
-    <PackageReference Include="Rebus.Tests.Contracts" Version="4.0.0" />
+    <PackageReference Include="microsoft.net.test.sdk" Version="16.5.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit3testadapter" Version="3.16.1" />
+    <PackageReference Include="Rebus" Version="6.0.0" />
+    <PackageReference Include="Rebus.Tests.Contracts" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework) == 'net451' ">
     <Reference Include="System.Transactions" />

--- a/Rebus.TransactionScopes/Rebus.TransactionScopes.csproj
+++ b/Rebus.TransactionScopes/Rebus.TransactionScopes.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="Rebus" Version="4.0.0" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework) == 'net451' ">
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/Rebus.TransactionScopes/Rebus.TransactionScopes.csproj
+++ b/Rebus.TransactionScopes/Rebus.TransactionScopes.csproj
@@ -42,7 +42,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Rebus" Version="4.0.0" />
+    <PackageReference Include="Rebus" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework) == 'net451' ">
     <Reference Include="System.Transactions" />

--- a/Rebus.TransactionScopes/TransactionScopes/TransactionScopeTransportDecorator.cs
+++ b/Rebus.TransactionScopes/TransactionScopes/TransactionScopeTransportDecorator.cs
@@ -33,8 +33,8 @@ namespace Rebus.TransactionScopes
             var scope = new TransactionScope(TransactionScopeOption.Required, _transactionOptions,
                 TransactionScopeAsyncFlowOption.Enabled);
 
-            context.OnCompleted(async () => scope.Complete());
-            context.OnDisposed(() => scope.Dispose());
+            context.OnCompleted(async ctx => scope.Complete());
+            context.OnDisposed(ctx => scope.Dispose());
 
             // stash current tx so we can re-attach it later
             context.Items[TransactionScopeIncomingStep.CurrentTransactionContextKey] = Transaction.Current;


### PR DESCRIPTION
* Upgrade Rebus package reference to version 6.0.0 and fix breaking change
* Make framework reference conditional
* Fix incorrect URLs in README

Fixes #9

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
