### PR TITLE
Fix issue with 2nd level retries

### DIFF
--- a/Rebus.TransactionScopes.Tests/Rebus.TransactionScopes.Tests.csproj
+++ b/Rebus.TransactionScopes.Tests/Rebus.TransactionScopes.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<Authors>mookid8000</Authors>
 		<PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
 		<PackageProjectUrl>https://rebus.fm/what-is-rebus/</PackageProjectUrl>
@@ -13,9 +13,9 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Rebus.TransactionScopes\Rebus.TransactionScopes.csproj" />
-		<PackageReference Include="microsoft.net.test.sdk" Version="17.8.0" />
+		<PackageReference Include="microsoft.net.test.sdk" Version="17.9.0" />
 		<PackageReference Include="nunit" Version="3.14.0" />
 		<PackageReference Include="nunit3testadapter" Version="4.5.0" />
-		<PackageReference Include="Rebus.Tests.Contracts" Version="8.0.1" />
+		<PackageReference Include="Rebus.Tests.Contracts" Version="8.2.6" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
We had issues with TransactionScopes and second level retries. Since the 2nd level retries are again send through the message pipeline, the step will again try to enlist a transaction. This will fail since the transaction is already aborted because of an exception.
I do not think that the second level retry handler should be handled within a transaction, so I checked the context en do not apply the logic if it is a failed message.
This should fix issue https://github.com/rebus-org/Rebus.TransactionScopes/issues/13
